### PR TITLE
make `yii-base-cli` run successfully standalone

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "yiisoft/di": "^3.0@dev",
         "yiisoft/log": "^3.0@dev",
         "yiisoft/cache": "^3.0@dev",
-        "hiqdev/composer-config-plugin": "^1.0@dev"
+        "hiqdev/composer-config-plugin": "^1.0@dev",
+        "yiisoft/view": "^3.0@dev"
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
bacause `yii-core` depends `view`, when only install `yii-base-cli`, `view` is also required.
otherwise it will cause error like
```
[14-Dec-2018 09:49:35 UTC] PHP Fatal error:  Interface 'yii\view\ViewContextInterface' not found in /..../vendor/yiisoft/yii-core/src/base/Controller.php on line 32
```

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  |no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
